### PR TITLE
Update the splash screen redirect navigator to accept named routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .DS_Store
 .dart_tool/
 

--- a/lib/splashscreen.dart
+++ b/lib/splashscreen.dart
@@ -1,12 +1,14 @@
 library splashscreen;
+import 'dart:core';
 import 'dart:async';
 import 'package:flutter/material.dart';
+
 class SplashScreen extends StatefulWidget {
   final int seconds;
   final Text title;
   final Color backgroundColor;
   final TextStyle styleTextUnderTheLoader;
-  final Widget navigateAfterSeconds;
+  final dynamic navigateAfterSeconds;
   final double photoSize;
   final dynamic onClick;
   final Color loaderColor;
@@ -38,7 +40,22 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    Timer(Duration(seconds: widget.seconds), ()=>Navigator.of(context).push(new MaterialPageRoute(builder: (BuildContext context)=> widget.navigateAfterSeconds)));
+    Timer(
+      Duration(seconds: widget.seconds),
+      () {
+        if (widget.navigateAfterSeconds is String) {
+          // It's fairly safe to assume this is using the in-built material
+          // named route component
+          return Navigator.of(context).pushNamed(widget.navigateAfterSeconds);
+        } else if (widget.navigateAfterSeconds is Widget) {
+          return Navigator.of(context).push(new MaterialPageRoute(builder: (BuildContext context) => widget.navigateAfterSeconds));
+        } else {
+          throw new ArgumentError(
+              'widget.navigateAfterSeconds must either be a String or Widget'
+          );
+        }
+      }
+    );
   }
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: splashscreen
 description: A small splashscreen used for an intro for any flutter application easily using
-version: 0.0.9
+version: 0.0.10
 author: Karim Mohamed <monkey4gamesmmm@gmail.com>
 homepage: https://github.com/KarimMohamed2005/SplashScreenFlutterPackage
 


### PR DESCRIPTION
I am using Material named routes in my application, which means that using this plugin breaks the flow a little. I have added a small conditional statement that allows me to pass a named route, and then have the navigator push that. 

Tested using my local application development environment.

Signed-off-by: Andrew Lowther <Andrew.Lowther@gentinguk.com>